### PR TITLE
Update freetype cmake file

### DIFF
--- a/freetype.cmake/CMakeLists.txt
+++ b/freetype.cmake/CMakeLists.txt
@@ -56,19 +56,13 @@ SET ( FT_MODULES
 
 ADD_LIBRARY(freetype ${BUNDLE_LIB_MODIFIER} ${FT_SOURCE_FILES} ${FT_MODULES} )  
 
-FILE(GLOB freetype_headers "${FT_DIR}/include/*.*")
-FILE(GLOB freetype_headers_ft "${FT_DIR}/include/freetype/*.*")
-FILE(GLOB_RECURSE freetype_headers_config "${FT_DIR}/include/freetype/config/*.*")
-FILE(GLOB_RECURSE freetype_headers_int "${FT_DIR}/include/freetype/internal/*.*")
-
-INSTALL (FILES ${freetype_headers} DESTINATION ${OCE_WIN_BUNDLE_INSTALL_DIR}/include/freetype )
-INSTALL (FILES ${freetype_headers_ft} DESTINATION ${OCE_WIN_BUNDLE_INSTALL_DIR}/include/freetype/freetype )
-INSTALL (FILES ${freetype_headers_config} DESTINATION ${OCE_WIN_BUNDLE_INSTALL_DIR}/include/freetype/freetype/config )
-INSTALL (FILES ${freetype_headers_int} DESTINATION ${OCE_WIN_BUNDLE_INSTALL_DIR}/include/freetype/freetype/internal )
-
+INSTALL(DIRECTORY ${FT_DIR}/include/
+    DESTINATION ${OCE_WIN_BUNDLE_INSTALL_DIR}/include/freetype
+    PATTERN "internal" EXCLUDE
+    )
 
 INSTALL(TARGETS freetype
-		ARCHIVE DESTINATION  "${OCE_WIN_BUNDLE_INSTALL_DIR_BITS}/lib/" CONFIGURATIONS Debug Release MinSizeRel RelWithDebInfo
-		LIBRARY DESTINATION  "${OCE_WIN_BUNDLE_INSTALL_DIR_BITS}/lib/" CONFIGURATIONS Debug Release MinSizeRel RelWithDebInfo
-		RUNTIME DESTINATION  "${OCE_WIN_BUNDLE_INSTALL_DIR_BITS}/bin/" CONFIGURATIONS Debug Release MinSizeRel RelWithDebInfo
-		)
+    ARCHIVE DESTINATION  "${OCE_WIN_BUNDLE_INSTALL_DIR_BITS}/lib/" CONFIGURATIONS Debug Release MinSizeRel RelWithDebInfo
+    LIBRARY DESTINATION  "${OCE_WIN_BUNDLE_INSTALL_DIR_BITS}/lib/" CONFIGURATIONS Debug Release MinSizeRel RelWithDebInfo
+    RUNTIME DESTINATION  "${OCE_WIN_BUNDLE_INSTALL_DIR_BITS}/bin/" CONFIGURATIONS Debug Release MinSizeRel RelWithDebInfo
+    )


### PR DESCRIPTION
The freetype 2.5.2 include files changed in the update from 2.49. This fixes the install step of the freetype cmake file.
