### PR TITLE
Added additional cmath include for MinGw64

### DIFF
--- a/libs/FreeImage/Source/OpenEXR/Imath/ImathMatrixAlgo.cpp
+++ b/libs/FreeImage/Source/OpenEXR/Imath/ImathMatrixAlgo.cpp
@@ -43,6 +43,11 @@
 //----------------------------------------------------------------------------
 
 #include "ImathMatrixAlgo.h"
+
+#if defined(__MINGW64__)
+    #include <cmath>
+#endif
+
 #include <algorithm>
 
 #if defined(OPENEXR_DLL)


### PR DESCRIPTION
Fix that makes oce-win-bundle compilable with MinGw64
